### PR TITLE
Add MVP VS Code grammar injection for Markdown in JSDoc comments

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,105 @@
+# JSDoc Markdown MVP
+
+A minimal VS Code extension that injects Markdown syntax highlighting **only** inside JSDoc block comments (`/** ... */`) for:
+
+- JavaScript (`.js`, `.mjs`, `.cjs`)
+- TypeScript (`.ts`)
+- JavaScript React (`.jsx`)
+- TypeScript React (`.tsx`)
+
+## What it does
+
+Inside JSDoc comments, common Markdown constructs are highlighted using VS Code's built-in Markdown TextMate grammar, including:
+
+- Inline code: `` `code` ``
+- Fenced code blocks: ```` ```ts ````
+- Emphasis: `*italic*`, `**bold**`
+- Links and lists
+
+## What it does not do (MVP limitations)
+
+- No background color setting for JSDoc blocks.
+- No dimming setting for non-Markdown text.
+- No Markdown preview/hover changes.
+- No language server behavior changes.
+- No custom parser; this extension is grammar-injection only.
+
+## Scope behavior
+
+- ✅ `/** ... */` (JSDoc) receives Markdown highlighting.
+- ❌ `/* ... */` (normal block comments) are unchanged.
+- ❌ `// ...` (line comments) are unchanged.
+
+## Run locally (Extension Development Host)
+
+1. Open this folder in VS Code.
+2. Press `F5` to launch the Extension Development Host.
+3. In the Dev Host window, open a `.js`, `.ts`, `.jsx`, or `.tsx` file.
+4. Add a JSDoc block and verify Markdown highlighting appears only there.
+
+## Manual validation checklist
+
+Use a sample file and verify all items:
+
+1. JSDoc comment highlights Markdown:
+
+```ts
+/**
+ * **bold** item
+ * `inline code`
+ * - list item
+ * [link](https://example.com)
+ */
+function demo() {}
+```
+
+2. Normal block comment is unchanged:
+
+```ts
+/* **bold** should stay plain comment-colored here */
+```
+
+3. Line comment is unchanged:
+
+```ts
+// `inline code` should stay plain comment-colored here
+```
+
+4. Repeat in `.jsx` and `.tsx` files.
+
+## Before/after screenshot instructions
+
+To document visual differences:
+
+1. Open the same file before enabling/installing this extension and capture a screenshot.
+2. Enable/install the extension, reload window, and capture the same region.
+3. Compare JSDoc sections only; non-JSDoc comments should look unchanged.
+
+## Optional color customization
+
+You can customize specific injected scopes in your `settings.json`:
+
+```json
+{
+  "editor.tokenColorCustomizations": {
+    "textMateRules": [
+      {
+        "scope": [
+          "meta.embedded.block.jsdoc-markdown markup.bold",
+          "meta.embedded.block.jsdoc-markdown markup.italic",
+          "meta.embedded.block.jsdoc-markdown markup.inline.raw",
+          "meta.embedded.block.jsdoc-markdown markup.fenced_code.block"
+        ],
+        "settings": {
+          "foreground": "#c586c0"
+        }
+      }
+    ]
+  }
+}
+```
+
+## Notes
+
+- This extension is intentionally minimal and contains no runtime activation code.
+- Cursor support is best-effort and depends on compatibility with standard VS Code extension grammar injection.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "jsdoc-markdown-mvp",
+  "displayName": "JSDoc Markdown MVP",
+  "description": "Highlights Markdown syntax inside JSDoc comments for JS/TS/JSX/TSX.",
+  "version": "0.0.1",
+  "publisher": "local",
+  "license": "MIT",
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "categories": [
+    "Programming Languages"
+  ],
+  "contributes": {
+    "grammars": [
+      {
+        "language": "javascript",
+        "scopeName": "injection.jsdoc.markdown",
+        "path": "./syntaxes/jsdoc-markdown.tmLanguage.json",
+        "injectTo": [
+          "source.js",
+          "source.ts",
+          "source.jsx",
+          "source.tsx"
+        ]
+      },
+      {
+        "language": "typescript",
+        "scopeName": "injection.jsdoc.markdown",
+        "path": "./syntaxes/jsdoc-markdown.tmLanguage.json",
+        "injectTo": [
+          "source.js",
+          "source.ts",
+          "source.jsx",
+          "source.tsx"
+        ]
+      },
+      {
+        "language": "javascriptreact",
+        "scopeName": "injection.jsdoc.markdown",
+        "path": "./syntaxes/jsdoc-markdown.tmLanguage.json",
+        "injectTo": [
+          "source.js",
+          "source.ts",
+          "source.jsx",
+          "source.tsx"
+        ]
+      },
+      {
+        "language": "typescriptreact",
+        "scopeName": "injection.jsdoc.markdown",
+        "path": "./syntaxes/jsdoc-markdown.tmLanguage.json",
+        "injectTo": [
+          "source.js",
+          "source.ts",
+          "source.jsx",
+          "source.tsx"
+        ]
+      }
+    ]
+  }
+}

--- a/syntaxes/jsdoc-markdown.tmLanguage.json
+++ b/syntaxes/jsdoc-markdown.tmLanguage.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "JSDoc Markdown Injection",
+  "scopeName": "injection.jsdoc.markdown",
+  "injectionSelector": "L:comment.block.documentation -string -meta.embedded",
+  "patterns": [
+    {
+      "name": "meta.embedded.block.jsdoc-markdown",
+      "begin": "(?<=/\\*\\*)",
+      "end": "(?=\\*/)",
+      "patterns": [
+        {
+          "include": "text.html.markdown"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation

- Provide an extremely small, grammar-only VS Code extension that enables Markdown syntax highlighting only inside JSDoc block comments (`/** ... */`) for JS/TS/JSX/TSX files.
- Keep runtime surface zero for MVP and rely on VS Code's built-in Markdown TextMate grammar via injection to avoid custom parsing or language-server changes.

### Description

- Added `package.json` with `contributes.grammars` entries for `javascript`, `typescript`, `javascriptreact`, and `typescriptreact` that register an injection grammar with `scopeName` `injection.jsdoc.markdown` and `injectTo` the JS/TS source scopes. 
- Added `syntaxes/jsdoc-markdown.tmLanguage.json`, an injection grammar that uses `injectionSelector` to target documentation block comments and embeds the existing Markdown grammar by including `text.html.markdown` between the `/**` and `*/` boundaries. 
- Added `README.md` documenting what the extension does, supported languages, MVP limitations, manual validation checklist, and an optional `editor.tokenColorCustomizations` snippet for users who want to tweak colors. 
- Added `LICENSE` (MIT) and kept the implementation intentionally free of activation/runtime code.

### Testing

- Validated `package.json` and `syntaxes/jsdoc-markdown.tmLanguage.json` are well-formed JSON by parsing both with `node` and the check completed successfully. 
- Confirmed the expected extension files are present in the workspace (`package.json`, `README.md`, `LICENSE`, and `syntaxes/jsdoc-markdown.tmLanguage.json`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699703730938832bad8f12c3a88e7a0c)