### PR TITLE
Remove italics/foreground options and snippet command; document token-based styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,26 +16,22 @@ Inside JSDoc comments, common Markdown constructs are highlighted using VS Code'
 - Emphasis: `*italic*`, `**bold**`
 - Links and lists
 
-It also adds optional runtime styling for JSDoc blocks:
+It also adds optional runtime background styling for JSDoc blocks:
 
 - Background color for the full `/** ... */` range.
-- Optional comment-italics neutralization (`fontStyle: normal`) so Markdown reads like regular text.
 
 ## Configuration
 
 ```json
 {
   "jsdocMarkdownStyle.enabled": true,
-  "jsdocMarkdownStyle.backgroundColor": "rgba(128, 128, 128, 0.08)",
-  "jsdocMarkdownStyle.removeItalics": true,
-  "jsdocMarkdownStyle.baseForegroundColor": null
+  "jsdocMarkdownStyle.backgroundColor": "rgba(128, 128, 128, 0.08)"
 }
 ```
 
 Notes:
 
 - Set `backgroundColor` to `null` or `""` to disable background fill.
-- Foreground token colors are untouched, so Markdown token coloring stays theme-driven.
 - JSDoc detection is a lightweight text scan (`/**` ... `*/`), so comment-like sequences inside strings may still be matched in edge cases.
 
 ## Scope behavior
@@ -57,19 +53,18 @@ Notes:
 Use a sample file and verify all items:
 
 1. JSDoc comment highlights Markdown and has background.
-2. JSDoc text is not italic when `removeItalics` is enabled.
-3. Normal block comments are unchanged.
-4. Line comments are unchanged.
-5. Repeat in `.jsx` and `.tsx` files.
+2. Normal block comments are unchanged.
+3. Line comments are unchanged.
+4. Repeat in `.jsx` and `.tsx` files.
 
 
-## Optional base foreground color (without breaking Markdown token colors)
+## Styling via token colors
 
-To avoid overriding Markdown token-level colors, this extension does **not** set decoration `color`.
-Instead, target the injected JSDoc scope with theme token customization.
+Foreground color and italics are best configured directly via `editor.tokenColorCustomizations`.
+Use these selectors:
 
-You can run the command **"JSDoc Markdown Style: Copy tokenColorCustomizations snippet"** (Command Palette) to copy a ready-to-paste JSON snippet that uses `jsdocMarkdownStyle.baseForegroundColor` when set.
-
+- `meta.jsdoc.markdown`: base JSDoc markdown text color/style.
+- `punctuation.definition.comment.jsdoc.leading`: the leading `*` markers in multi-line JSDoc blocks.
 
 ```json
 {
@@ -81,6 +76,12 @@ You can run the command **"JSDoc Markdown Style: Copy tokenColorCustomizations s
           "foreground": "#AABBCC",
           "fontStyle": ""
         }
+      },
+      {
+        "scope": "punctuation.definition.comment.jsdoc.leading",
+        "settings": {
+          "foreground": "#6A737D"
+        }
       }
     ]
   }
@@ -88,6 +89,5 @@ You can run the command **"JSDoc Markdown Style: Copy tokenColorCustomizations s
 ```
 
 Notes:
+- Set `fontStyle` to `""` to remove italics.
 - More specific Markdown scopes (inline code, headings, bold, links, etc.) still win, so their colors remain unchanged.
-- `jsdocMarkdownStyle.removeItalics` is still handled by editor decorations (`fontStyle: normal`).
-- `jsdocMarkdownStyle.baseForegroundColor` is used as the foreground value in the copied snippet; apply the snippet via `editor.tokenColorCustomizations`.

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
 		"onLanguage:javascript",
 		"onLanguage:typescript",
 		"onLanguage:javascriptreact",
-		"onLanguage:typescriptreact",
-		"onCommand:jsdocMarkdownStyle.copyTokenColorCustomizationSnippet"
+		"onLanguage:typescriptreact"
 	],
 	"scripts": {
 		"build": "tsc -p .",
@@ -53,7 +52,7 @@
 				"jsdocMarkdownStyle.enabled": {
 					"type": "boolean",
 					"default": true,
-					"description": "Enable JSDoc block background and italics override styling."
+					"description": "Enable JSDoc block background styling."
 				},
 				"jsdocMarkdownStyle.backgroundColor": {
 					"type": [
@@ -62,27 +61,8 @@
 					],
 					"default": "rgba(128, 128, 128, 0.08)",
 					"description": "Background color for JSDoc blocks. Set to null or empty string to disable background."
-				},
-				"jsdocMarkdownStyle.removeItalics": {
-					"type": "boolean",
-					"default": true,
-					"description": "Render JSDoc text with normal font style to avoid inheriting comment italics."
-				},
-				"jsdocMarkdownStyle.baseForegroundColor": {
-					"type": [
-						"string",
-						"null"
-					],
-					"default": null,
-					"description": "Optional base foreground color hint for JSDoc markdown text. Configure via editor.tokenColorCustomizations using scope meta.jsdoc.markdown."
 				}
 			}
-		},
-		"commands": [
-			{
-				"command": "jsdocMarkdownStyle.copyTokenColorCustomizationSnippet",
-				"title": "JSDoc Markdown Style: Copy tokenColorCustomizations snippet"
-			}
-		]
+		}
 	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -81,36 +81,6 @@ export function activate(context: vscode.ExtensionContext): void {
     })
   );
 
-
-  context.subscriptions.push(
-    vscode.commands.registerCommand('jsdocMarkdownStyle.copyTokenColorCustomizationSnippet', async () => {
-      const configuredColor = normalizeString(
-        vscode.workspace.getConfiguration(CONFIG_NAMESPACE).get<string | null>('baseForegroundColor')
-      );
-      const foreground = configuredColor ?? '#AABBCC';
-      const snippet = JSON.stringify(
-        {
-          'editor.tokenColorCustomizations': {
-            textMateRules: [
-              {
-                scope: 'meta.jsdoc.markdown',
-                settings: {
-                  foreground,
-                  fontStyle: ''
-                }
-              }
-            ]
-          }
-        },
-        null,
-        2
-      );
-
-      await vscode.env.clipboard.writeText(snippet);
-      void vscode.window.showInformationMessage('Copied tokenColorCustomizations snippet for meta.jsdoc.markdown.');
-    })
-  );
-
   context.subscriptions.push({
     dispose: () => {
       for (const timer of pendingUpdates.values()) {
@@ -126,16 +96,12 @@ export function activate(context: vscode.ExtensionContext): void {
 function createDecorationType(): vscode.TextEditorDecorationType {
   const config = vscode.workspace.getConfiguration(CONFIG_NAMESPACE);
   const backgroundColor = normalizeString(config.get<string | null>('backgroundColor'));
-  const removeItalics = config.get<boolean>('removeItalics', true);
 
   const options: vscode.DecorationRenderOptions = {
     isWholeLine: true
   };
   if (backgroundColor) {
     options.backgroundColor = backgroundColor;
-  }
-  if (removeItalics) {
-    options.fontStyle = 'normal';
   }
 
   return vscode.window.createTextEditorDecorationType(options);


### PR DESCRIPTION
### Motivation
- The extension exposed runtime options for base foreground color and removing italics plus a helper command, but these are better handled by theme token customizations and not by decorations applied at runtime.

### Description
- Removed `jsdocMarkdownStyle.removeItalics` and `jsdocMarkdownStyle.baseForegroundColor` from `package.json` and removed the command activation event.
- Removed the `jsdocMarkdownStyle.copyTokenColorCustomizationSnippet` command registration and implementation from `src/extension.ts`.
- Stopped reading the removed settings and removed application of `fontStyle` from the decoration so the extension now only applies an optional background fill.
- Updated `README.md` to instruct configuring foreground color and italics via `editor.tokenColorCustomizations` and to recommend the `meta.jsdoc.markdown` and `punctuation.definition.comment.jsdoc.leading` selectors with an example JSON snippet.

### Testing
- Ran `npm run build` which invokes `tsc -p .`, and TypeScript compilation completed successfully.
- Confirmed the repository builds cleanly after the changes with no compiler errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69987ebdc45c832b9701c43fb8592127)