### PR TITLE
Adjust JSDoc background decoration to exclude delimiters

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -129,7 +129,14 @@ function expandToWholeLineRanges(document: vscode.TextDocument, blockRanges: vsc
   const lineRanges: vscode.Range[] = [];
 
   for (const blockRange of blockRanges) {
-    for (let line = blockRange.start.line; line <= blockRange.end.line; line += 1) {
+    const firstContentLine = blockRange.start.line + 1;
+    const lastContentLine = blockRange.end.line - 1;
+
+    if (firstContentLine > lastContentLine) {
+      continue;
+    }
+
+    for (let line = firstContentLine; line <= lastContentLine; line += 1) {
       lineRanges.push(document.lineAt(line).range);
     }
   }


### PR DESCRIPTION
### Motivation
- The background decoration was being applied to entire JSDoc blocks including the delimiter lines (`/**` and `*/`), but the syntax highlight is only applied to the inner content lines; the background should match that behavior.

### Description
- Modified `expandToWholeLineRanges` in `src/extension.ts` to compute `firstContentLine = start.line + 1` and `lastContentLine = end.line - 1` and only decorate those inner lines.
- Added a guard to skip blocks where `firstContentLine > lastContentLine`, which naturally prevents single-line JSDoc comments from receiving background styling.

### Testing
- Ran `npm run build` and TypeScript compiled successfully (build passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69988897a350832bb026a006a7f6d1f0)