### PR TITLE
Unify background config into single nullable color option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ It also adds optional runtime background styling for JSDoc blocks:
 
 ```json
 {
-  "jsdocMarkdownStyle.enabled": true,
-  "jsdocMarkdownStyle.backgroundColor": "rgba(128, 128, 128, 0.08)"
+  "jsdocMarkdownStyle.backgroundColor": "rgba(0, 0, 0, 0.1)"
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -49,17 +49,12 @@
 		"configuration": {
 			"title": "JSDoc Markdown Style",
 			"properties": {
-				"jsdocMarkdownStyle.enabled": {
-					"type": "boolean",
-					"default": true,
-					"description": "Enable JSDoc block background styling."
-				},
 				"jsdocMarkdownStyle.backgroundColor": {
 					"type": [
 						"string",
 						"null"
 					],
-					"default": "rgba(128, 128, 128, 0.08)",
+					"default": "rgba(0, 0, 0, 0.1)",
 					"description": "Background color for JSDoc blocks. Set to null or empty string to disable background."
 				}
 			}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -112,10 +112,7 @@ function applyDecorations(editor: vscode.TextEditor): void {
     return;
   }
 
-  const config = vscode.workspace.getConfiguration(CONFIG_NAMESPACE);
-  const enabled = config.get<boolean>('enabled', true);
-
-  if (!enabled || !SUPPORTED_LANGUAGES.has(editor.document.languageId)) {
+  if (!SUPPORTED_LANGUAGES.has(editor.document.languageId)) {
     editor.setDecorations(decorationType, []);
     return;
   }


### PR DESCRIPTION
### Motivation
- Simplify background styling configuration by merging the separate enable flag and the color into a single setting so presence/absence of a color controls whether a background is applied.
- Make the default background slightly darker and consistent with a translucent black look by switching to a 10% opacity black default.

### Description
- Removed the runtime `jsdocMarkdownStyle.enabled` gating and now rely on the `backgroundColor` contribution to control visual background behavior at creation time (`src/extension.ts`).
- Updated contributed settings to only expose `jsdocMarkdownStyle.backgroundColor` and set its default to `rgba(0, 0, 0, 0.1)` (`package.json`).
- Updated the `README.md` configuration example to reflect the single nullable color configuration and the new default value (`README.md`).

### Testing
- Ran `npm run build` and the TypeScript compilation completed successfully without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998d859f280832b9bee2b505188959a)